### PR TITLE
Fix e2e test_gradle cleanup failing on busy ~/.gradle/init.d

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -90,8 +90,13 @@ workflows:
         inputs:
         - content: |-
             set -ex
-            sudo rm -rf .gradle
-            sudo rm -rf ~/.gradle
+            # Stop the daemon so it doesn't race with the cleanup below.
+            ./gradlew -stop || true
+            # Skip ~/.gradle/init.d — populated by the Bitrise stack image and
+            # held open on the noble-24.04 docker stack, which causes
+            # `rm -rf ~/.gradle` to fail with "Device or resource busy".
+            find ~/.gradle -mindepth 1 -maxdepth 1 ! -name init.d -exec rm -rf {} +
+            rm -rf .gradle
     - path::./:
         title: Restore cache
         run_if: "true"


### PR DESCRIPTION
## Summary
The nightly batch CI for this step was failing in the e2e `test_gradle` workflow at the **Delete local Gradle caches** step:

```
+ sudo rm -rf /root/.gradle
rm: cannot remove '/root/.gradle/init.d': Device or resource busy
exit status 1
```

The step wiped the entire `~/.gradle` to simulate a clean machine before restoring the cache. On the current noble-24.04 docker stack, `~/.gradle/init.d` is held open (the stack injects Gradle init scripts there), so `rm -rf ~/.gradle` fails with *Device or resource busy* and the test errors out.

## Fix
Delete everything under `~/.gradle` **except** `init.d`, and stop the Gradle daemon first so it doesn't race with the cleanup:

```bash
./gradlew -stop || true
find ~/.gradle -mindepth 1 -maxdepth 1 ! -name init.d -exec rm -rf {} +
rm -rf .gradle
```

This still removes the cached `~/.gradle/caches` and `~/.gradle/wrapper` (so the subsequent Restore + verify steps exercise a real cache hit), while leaving the busy `init.d` mount untouched.

Mirrors the approach already merged in [`bitrise-step-restore-gradle-cache`](https://github.com/bitrise-steplib/bitrise-step-restore-gradle-cache/blob/master/e2e/bitrise.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)